### PR TITLE
Support arbitrary UIDs for CONF_DIR

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -10,3 +10,8 @@ ENV SSL_TRUSTSTORE=$CONF_DIR/truststore.p12 \
 COPY include $CONF_DIR
 
 RUN $CONF_DIR/truststore-setup.sh
+
+USER root
+RUN chmod -R g=u $CONF_DIR
+
+USER 185

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ if [ -z "$IMAGE" ]; then
 fi
 
 if [ -z "$TAG" ]; then
-    TAG="0.1.0"
+    TAG="0.2.0"
 fi
 
 if [ -z "$BUILDER" ]; then


### PR DESCRIPTION
When deploying a Cryostat 2.0.0-SNAPSHOT image on OpenShift using the operator, Cryostat fails to start with the following error:
```
keytool error: java.io.FileNotFoundException: /opt/cryostat.d/truststore.p12 (Permission denied)
java.io.FileNotFoundException: /opt/cryostat.d/truststore.p12 (Permission denied)
	at java.base/java.io.FileOutputStream.open0(Native Method)
	at java.base/java.io.FileOutputStream.open(FileOutputStream.java:298)
	at java.base/java.io.FileOutputStream.<init>(FileOutputStream.java:237)
	at java.base/java.io.FileOutputStream.<init>(FileOutputStream.java:126)
	at java.base/sun.security.tools.keytool.Main.doCommands(Main.java:1324)
	at java.base/sun.security.tools.keytool.Main.run(Main.java:409)
	at java.base/sun.security.tools.keytool.Main.main(Main.java:402)
```
This is because of OpenShift using arbitrary UIDs for containers. In order for the truststore to be writable by the Cryostat container, it must be group-writable. [1]

Before fix:
```
$ ls -l /opt/cryostat.d/
total 176
-rwxr-xr-x. 1 root  root    473 Apr 30 22:25 truststore-setup.sh
-rw-r--r--. 1 jboss root 169460 Apr 30 22:26 truststore.p12
-rw-r--r--. 1 jboss root     33 Apr 30 22:26 truststore.pass
```

After fix:
```
$ ls -l /opt/cryostat.d/
total 176
-rwxrwxr-x. 1 root  root    473 Apr 30 20:11 truststore-setup.sh
-rw-rw-r--. 1 jboss root 169460 May 27 19:16 truststore.p12
-rw-rw-r--. 1 jboss root     33 May 27 19:16 truststore.pass
```

[1] https://docs.openshift.com/container-platform/4.7/openshift_images/create-images.html#images-create-guide-openshift_create-images