### PR TITLE
feat(base): use runtime base image variant

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -3,6 +3,13 @@ ARG BASE_IMAGE=registry.access.redhat.com/ubi8/openjdk-11-runtime
 ARG IMAGE_TAG=@sha256:32219d7c7d82112481293d67951fa071f35e78453e01a5d3246cc040698adf49
 FROM ${BASE_IMAGE}${IMAGE_TAG}
 
+USER root
+
+RUN microdnf --disableplugin=subscription-manager -y install findutils && \
+    microdnf --disableplugin=subscription-manager -y clean all
+
+USER 185
+
 ENV CONF_DIR=/opt/cryostat.d
 
 RUN mkdir -p $CONF_DIR

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,7 @@
-FROM registry.access.redhat.com/ubi8/openjdk-11:1.3-15
+ARG BASE_IMAGE=registry.access.redhat.com/ubi8/openjdk-11-runtime
+# 1.9-1.1622550112
+ARG IMAGE_TAG=@sha256:32219d7c7d82112481293d67951fa071f35e78453e01a5d3246cc040698adf49
+FROM ${BASE_IMAGE}${IMAGE_TAG}
 
 ENV CONF_DIR=/opt/cryostat.d
 

--- a/include/truststore-setup.sh
+++ b/include/truststore-setup.sh
@@ -16,7 +16,7 @@ pushd $CONF_DIR
 keytool -importkeystore \
     -noprompt \
     -storetype PKCS12 \
-    -srckeystore /usr/lib/jvm/java-11-openjdk/lib/security/cacerts \
+    -srckeystore /usr/lib/jvm/jre-11-openjdk/lib/security/cacerts \
     -srcstorepass changeit \
     -destkeystore "$SSL_TRUSTSTORE" \
     -deststorepass "$SSL_TRUSTSTORE_PASS"


### PR DESCRIPTION
```
$ TAG=0.3.0 sh build.sh
...
$ podman images | grep base
quay.io/cryostat/cryostat-base                      latest                  b3a9fe86b761  2 minutes ago   382 MB
quay.io/cryostat/cryostat-base                      0.3.0                   b3a9fe86b761  2 minutes ago   382 MB
quay.io/cryostat/cryostat-base                      0.2.0                   7ab53fd4bef7  6 weeks ago     630 MB
```

I tested this out with a `cryostat` image built on top of this newer base and everything still looks green. Integration tests and smoketesting passes just fine. I had to `microdnf install findutils` into the image so that the Cryostat entrypoint.sh can use `find` still, otherwise it works out of the box.